### PR TITLE
Fixing it so tokens can be deleted

### DIFF
--- a/product/opni/components/Tokens.vue
+++ b/product/opni/components/Tokens.vue
@@ -92,7 +92,7 @@ export default {
         this.loading = true;
         const [clusters, tokens] = await Promise.all([
           getClusters(),
-          getTokens(),
+          getTokens(this),
         ]);
 
         this.$set(this, 'tokens', tokens);


### PR DESCRIPTION
We needed to include the vue instance as a part of the getTokens request on the list page.

rancher/opni#34
![token-delete](https://user-images.githubusercontent.com/55104481/177420146-3d31811e-922f-4bec-8ed7-9079357afbb2.gif)