### PR TITLE
Updating how we specify labels when we create a cluster. The existing immutable labels needed to be specified.

### DIFF
--- a/product/opni/components/Cluster.vue
+++ b/product/opni/components/Cluster.vue
@@ -80,7 +80,7 @@ export default {
 
   methods: {
     save() {
-      updateCluster(this.newCluster.id, this.name, this.labels);
+      updateCluster(this.newCluster.id, this.name, { ...(this.newCluster.labels || {}), ...this.labels });
 
       this.$router.replace({ name: 'clusters' });
     },


### PR DESCRIPTION
rancher/opni#705