### PR TITLE
Fixing timestamps on our charts

### DIFF
--- a/public/components/AnomalyChart/AnomalyChart.tsx
+++ b/public/components/AnomalyChart/AnomalyChart.tsx
@@ -61,7 +61,7 @@ export default class InsightsChart extends Component<AnomalyChartProps, AnomalyC
 
   render() {
     function xFormat(ms) {
-      return moment(ms).format('HH:MM');
+      return moment(ms).format('HH:mm');
     }
 
     const getBars = () => {

--- a/public/components/InsightsChart/InsightsChart.tsx
+++ b/public/components/InsightsChart/InsightsChart.tsx
@@ -73,7 +73,7 @@ export default class InsightsChart extends Component<InsightsChartProps, Insight
 
   render() {
     function xFormat(ms) {
-      return moment(ms).format('HH:MM');
+      return moment(ms).format('HH:mm');
     }
 
     const keywords = this.props.keywords.length > 0 


### PR DESCRIPTION
It was displaying the month due to a formatting issue instead of the minutes

rancher/opni#730 