### PR TITLE
Enable dashboards by default + misc bugfixes

### DIFF
--- a/product/opni/components/DashboardDetails.vue
+++ b/product/opni/components/DashboardDetails.vue
@@ -96,7 +96,7 @@ export default {
       </div>
     </div>
     <div v-else slot="body" class="not-enabled">
-      <h5>The Dashboard is not currently enabled. Enabling it will install it on the available agents.</h5>
+      <h5>The Dashboard is not currently enabled. Enabling it will install additional resources.</h5>
       <button class="btn role-primary" @click="$emit('enable')">
         Enable
       </button>

--- a/product/opni/components/LoggingConfig.vue
+++ b/product/opni/components/LoggingConfig.vue
@@ -64,7 +64,7 @@ export default {
         DataRetention: '7d',
         NodePools:     [createEmptyPool(1)],
         Dashboards:    {
-          Enabled: false, Replicas: 1, Resources: { Limits: {}, Requests: {} }
+          Enabled: true, Replicas: 1, Resources: { Limits: {}, Requests: {} }
         },
       }
     };
@@ -91,7 +91,6 @@ export default {
 
     disableDashboard() {
       this.$set(this.config.Dashboards, 'Enabled', false);
-      this.save(() => {});
     },
 
     numberSuffix(i) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5115,8 +5115,8 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001133, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
+  version "1.0.30001429"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz"
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- Enable dashboards by default when installing logging and monitoring capabilities
- Prevent filesystem storage backend from being selected when in standalone mode ([#712](https://github.com/rancher/opni/issues/712))
- Fix inconsistent not-enabled label text in logging dashboard config 
- Do not auto-apply when disabling dashboard before applying the capability config 
- Fix check for required grafana hostname field
- Temporarily disable auto-filling the grafana hostname 
- Hide the monitoring disable button when configuring and monitoring is not installed yet 
- Update caniuse-lite