### PR TITLE
Fixing the log templates page

### DIFF
--- a/public/components/TemplatesTable/TemplatesTable.tsx
+++ b/public/components/TemplatesTable/TemplatesTable.tsx
@@ -4,6 +4,9 @@ import React, { Component } from 'react';
 import {
   EuiPanel,
   EuiBasicTable,
+  EuiText,
+  EuiSpacer,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 
 import Loading from '../Loading';
@@ -52,6 +55,8 @@ export default class EventsTable extends Component<TemplatesTableProps, Template
 
     const templates = (await templatesRequest)
       .map((template, i) => ({...template, id: i}));
+
+    console.log(templates.length, templates);
 
     this.setState({
       templates,
@@ -121,17 +126,43 @@ export default class EventsTable extends Component<TemplatesTableProps, Template
       return agg;
     }, {});
 
+    const resultsCount =
+    this.state.pagination.pageSize === 0 ? (
+      <strong>All</strong>
+    ) : (
+      <>
+        <strong>
+          {this.state.pagination.pageSize * this.state.pagination.pageIndex + 1}-{Math.min(this.state.pagination.pageSize * this.state.pagination.pageIndex + this.state.pagination.pageSize, this.state.pagination.totalItemCount)}
+        </strong>{' '}
+        of {this.state.pagination.totalItemCount}
+      </>
+    );
+
     return (
       <div className="events-table" style={{ padding: '15px 15px', paddingTop: 0 }}>
           <EuiPanel>
             <Loading promise={this.state.templatesRequest}>
-              <EuiBasicTable
-                pagination={this.state.pagination}
-                items={getPagedTemplates()}
-                columns={columns}
-                itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-                onChange={onChange}
-              />
+              <div>
+                <div>
+                  <EuiText size="xs">
+                    Showing {resultsCount} <strong>Log Templates</strong>
+                  </EuiText>
+                </div>
+                <div>
+                  <EuiSpacer size="s" />
+                  <EuiHorizontalRule margin="none" style={{ height: 1 }} />
+                  <EuiSpacer size="s" />
+                </div>
+                <div>
+                  <EuiBasicTable
+                    pagination={this.state.pagination}
+                    items={getPagedTemplates()}
+                    columns={columns}
+                    itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+                    onChange={onChange}
+                  />
+                </div>
+              </div>
             </Loading>
           </EuiPanel>
         </div>

--- a/public/pages/Templates/Templates.tsx
+++ b/public/pages/Templates/Templates.tsx
@@ -50,10 +50,6 @@ export default class Events extends Component<any, EventsState> {
       range: this.getAbsoluteRange(this.state.settings.range),
       cluster: this.state.settings.cluster
     });
-
-    setTimeout(() => {
-      this.loadEvents();
-    });
   };
 
   load = async () => {
@@ -62,15 +58,9 @@ export default class Events extends Component<any, EventsState> {
       clustersRequest
     });
 
-    await this.loadEvents();
-
     this.setState({
       clusters: await clustersRequest
     });
-  };
-
-  loadEvents = async () => {
-
   };
 
   render() {

--- a/public/utils/requests.ts
+++ b/public/utils/requests.ts
@@ -242,10 +242,11 @@ export async function getLogTemplates(range: Range, clusterId: string): Promise<
   const templates = templatesResponse.rawResponse.hits.hits;
 
   const allData = templates.map(at => {
-    const found = templateLogCountLookup[at._id];
+    const id = at._source.doc.template_cluster_id;
+    const found = templateLogCountLookup[id];
 
     return {
-      templateId: at._id,
+      templateId: id,
       count: found?.count || 0,
       template: at._source.doc.template_matched,
       log: at._source.doc.log
@@ -253,6 +254,7 @@ export async function getLogTemplates(range: Range, clusterId: string): Promise<
   });
 
   const dataWithCounts = allData.filter(d => d.count);
+  console.log('fffff', dataWithCounts, allData);
   return sortBy(dataWithCounts, 'count').reverse();
 }
 
@@ -625,7 +627,7 @@ function getLogTemplatesQuery(range: Range, clusterId: string) {
     "size": 0,
     "aggs": {
       "templates": {
-        "terms": { "field": "template_cluster_id", "size": 10000 },
+        "terms": { "field": "template_cluster_id", "size": 30000 },
       },
     },
   }


### PR DESCRIPTION
We weren't showing all of the log templates because the templates index has docs with an id that doesn't exactly match the logging index docs template_cluster_id. I switched to using template_cluster_id in the logging index.

![image](https://user-images.githubusercontent.com/55104481/217377262-58b1a431-029b-41c5-94bf-8e5724e77317.png)
