### PR TITLE
Fixing a bug where when you set an endpoint in the Monitoring config page you wouldn't see it when reloading the page

### DIFF
--- a/product/opni/components/MonitoringBackend/Storage.vue
+++ b/product/opni/components/MonitoringBackend/Storage.vue
@@ -19,7 +19,9 @@ export default {
   },
 
   created() {
-    this.updateEndpoint();
+    if (!this.value.storage.s3.endpoint) {
+      this.updateEndpoint();
+    }
   },
 
   data() {


### PR DESCRIPTION
rancher/opni#1009