### PR TITLE
Adding labels to the charts on the insights page to make it clear what they are

### DIFF
--- a/public/components/AnomalyChart/AnomalyChart.tsx
+++ b/public/components/AnomalyChart/AnomalyChart.tsx
@@ -2,7 +2,7 @@ import './style.scss';
 
 import React, { Component } from 'react';
 import {
-  EuiPanel,
+  EuiPanel, EuiTitle,
 } from '@elastic/eui';
 import {
   Chart,
@@ -97,6 +97,9 @@ export default class InsightsChart extends Component<AnomalyChartProps, AnomalyC
     return (
         <div className="anomaly-chart">
           <EuiPanel>
+              <EuiTitle size="xs" >
+                <h2>Control Plane Anomalies</h2>
+              </EuiTitle>
               <Loading promise={this.state.anomalyRequest}>
                   <Chart size={{ height: 300 }}>
                       <Settings showLegend={true} legendPosition="bottom" tooltip={{headerFormatter: (data) => xFormat(data.value)}}/>

--- a/public/components/AnomalyChart/style.scss
+++ b/public/components/AnomalyChart/style.scss
@@ -2,4 +2,8 @@
     .loading {
         height: 300px;
     }
+
+    h2 {
+        text-align: center;
+    }
 }

--- a/public/components/InsightsChart/InsightsChart.tsx
+++ b/public/components/InsightsChart/InsightsChart.tsx
@@ -3,7 +3,8 @@ import './style.scss';
 import React, { Component } from 'react';
 import {
   EuiPanel,
-  EuiIcon
+  EuiIcon,
+  EuiTitle
 } from '@elastic/eui';
 import {
   Chart,
@@ -26,6 +27,7 @@ export interface InsightsChartProps {
   granularity: Granularity; 
   clusterId: string;
   keywords: string[];
+  showTitle?: boolean;
   insightsProvider(range: Range, granularity: Granularity, clusterId: string, keywords: string[]): Promise<Insight[]>;
   eventsProvider?(range: Range, clusterId: string): Promise<K8SEvent[]>;
 };
@@ -121,9 +123,16 @@ export default class InsightsChart extends Component<InsightsChartProps, Insight
         />
       : null;
 
+    const title = this.props.showTitle 
+      ? <EuiTitle size="xs" >
+          <h2>Overall Insights</h2>
+        </EuiTitle>
+      : null;
+
     return (
         <div className="insights-chart">
           <EuiPanel>
+              {title}
               <Loading promise={this.state.loadingPromise}>
                   <Chart size={{ height: 300 }}>
                       <Settings showLegend={true} legendPosition="bottom" tooltip={{headerFormatter: (data) => xFormat(data.value)}}/>

--- a/public/components/InsightsChart/style.scss
+++ b/public/components/InsightsChart/style.scss
@@ -24,6 +24,10 @@
             }
         }
     }
+
+    h2 {
+        text-align: center;
+    }
 }
 
 .event-tooltip {

--- a/public/pages/Insights/Insights.tsx
+++ b/public/pages/Insights/Insights.tsx
@@ -84,7 +84,7 @@ class Main extends Component<any, MainState> {
       <PrimaryLayout loadingPromise={this.state.clustersRequest}>
         <Selector settings={this.state.settings} onChange={this.onSettingsChange} clusterIds={this.state.clusters} onRefresh={this.onRefresh}/>
         <EuiFlexGroup style={{ padding: '0 15px' }} className="selector">
-          <EuiFlexItem><InsightsChart range={this.state.range} granularity={this.state.granularity} clusterId={this.state.cluster} insightsProvider={getInsights} eventsProvider={(range, clusterId) => getK8sEvents(range, clusterId, 'Warning')} keywords={this.state.keywords} /></EuiFlexItem>
+          <EuiFlexItem><InsightsChart range={this.state.range} granularity={this.state.granularity} clusterId={this.state.cluster} insightsProvider={getInsights} eventsProvider={(range, clusterId) => getK8sEvents(range, clusterId, 'Warning')} keywords={this.state.keywords} showTitle={true} /></EuiFlexItem>
           <EuiFlexItem><AnomalyChart range={this.state.range} granularity={this.state.granularity} clusterId={this.state.cluster} /></EuiFlexItem>
         </EuiFlexGroup>
         <Breakdowns granularity={this.state.granularity} range={this.state.range} clusterId={this.state.cluster} keywords={this.state.keywords} />


### PR DESCRIPTION
rancher/opni#1046

![image](https://user-images.githubusercontent.com/55104481/218559197-867957c2-e1d1-48d5-aaef-fe02d0457d5b.png)
