### PR TITLE
Enable host metrics by default when using otel driver

### DIFF
--- a/pkg/opni/utils/requests/node-configuration.ts
+++ b/pkg/opni/utils/requests/node-configuration.ts
@@ -19,5 +19,5 @@ const PROMETHEUS_CONFIG = {
 
 const OTEL_CONFIG = {
   rules:  { discovery: { prometheusRules: {} } },
-  otel:  { hostMetrics: false }
+  otel:  { hostMetrics: true }
 };


### PR DESCRIPTION
Fixes https://github.com/rancher/opni/issues/1443 (with https://github.com/rancher/opni/pull/1445)